### PR TITLE
made a few steps more explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ is to install node via the "node version manager".
 
 ```bash
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+```
+
+open a new terminal or source your .bashrc and then:
+```bash
 nvm install node
 ```
 
@@ -27,10 +31,20 @@ nvm install node
 
 - [See the install page](https://gohugo.io/getting-started/installing/)
 
+one example for Linux/WSL:
+```bash
+wget https://github.com/gohugoio/hugo/releases/download/v0.92.2/hugo_extended_0.92.2_Linux-64bit.tar.gz
+tar xfz hugo_extended_0.92.2_Linux-64bit.tar.gz
+echo "export PATH=`pwd`:\$PATH" >> ~/.bashrc
+source ~/.bashrc
+which hugo
+```
+
 ### Clone repo and its submodules
 
 ```
-git clone --recurse-submodules
+git clone --recurse-submodules https://github.com/brainhackorg/brainhack_cloud
+cd brainhack_cloud
 ```
 
 If you have only cloned the repo and did not get all the submodules (`docsy` and `docsy`'s own subdmodules),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ nvm install node
 
 - [See the install page](https://gohugo.io/getting-started/installing/)
 
-one example for Linux/WSL:
+one example for Linux or for the [Windows Sub-system for Linux](https://docs.microsoft.com/en-us/windows/wsl/install):
 ```bash
 wget https://github.com/gohugoio/hugo/releases/download/v0.92.2/hugo_extended_0.92.2_Linux-64bit.tar.gz
 tar xfz hugo_extended_0.92.2_Linux-64bit.tar.gz


### PR DESCRIPTION
- made the new terminal explicit
- gave an install example for hugo extended (because the normal hugo doens't do it) on Linux/WSL
- this now works for me on WSL2 with Debian on Windows 10