### PR TITLE
Add license to all pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,7 +93,7 @@ home = ["HTML", "RSS", "JSON"]
 section = ["HTML", "print", "RSS"]
 
 [params]
-# copyright = "The Docsy Authors"
+copyright = "Brainhack Cloud <br> Except where otherwise noted, content on this site is licensed under a [CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0/)."
 # privacy_policy = "https://policies.google.com/privacy"
 
 # First one is picked as the Twitter card image if not set on page.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,39 @@
+{{ $links := .Site.Params.links }}
+<footer class="bg-dark py-4 row d-print-none">
+  <div class="container-fluid mx-sm-5">
+    <div class="row">
+      <div class="col-6 col-sm-4 text-xs-center order-sm-2 my-auto">
+        {{ with $links }}
+        {{ with index . "user"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3 my-auto">
+        {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-12 col-sm-4 text-center py-2 order-sm-2 my-auto">
+        {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ . | markdownify | emojify }} </small>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+	{{ if not .Site.Params.ui.footer_about_disable }}
+		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+	{{ end }}
+      </div>
+    </div>
+  </div>
+</footer>
+{{ define "footer-links-block" }}
+<ul class="list-inline mb-0">
+  {{ range . }}
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+      <i class="{{ .icon }}"></i>
+    </a>
+  </li>
+  {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
Takes care of #3.

The `copyright` field in `config.toml` is now markdown friendly, so any input will be converted.

![image](https://user-images.githubusercontent.com/30598330/161393750-f8fad480-2e78-40cd-93b4-a9a02a56afc0.png)
