### PR TITLE
Making oracle logos a hyperlink

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -18,7 +18,9 @@ linkTitle = "Brainhack cloud"
 		<p>
 			<img src = "logo.png" style="width:200px; padding:10px" alt="brainhack logo">
 			<br>
-			<img src="oracle.png" style="width:200px; padding:10px">
+			<a href="https://www.oracle.com/research/?source=:pp:sn:::::RC_WWMK211117P00113:Evergreen_General_WWMK211117P00113_Sponshorship">
+				<img src="oracle.png" style="width:200px; padding:10px">
+			</a>
 		</p>
 	</div>
 </section>

--- a/content/en/admins/_index.md
+++ b/content/en/admins/_index.md
@@ -25,7 +25,9 @@ on Github. For issues with the _Brainhack Cloud_, please open a
 Thank you to Oracle for Research for providing Oracle Cloud credits and related
 resources to support this project.
 
-<img src="https://user-images.githubusercontent.com/4021595/119061922-db877080-ba18-11eb-9882-d53a25ec88ee.png" width="250">
+<a href="https://www.oracle.com/research/?source=:pp:sn:::::RC_WWMK211117P00113:Evergreen_General_WWMK211117P00113_Sponshorship">
+  <img src="https://user-images.githubusercontent.com/4021595/119061922-db877080-ba18-11eb-9882-d53a25ec88ee.png" width="250">
+</a>
 
 ## License
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -27,7 +27,9 @@ on Github. For issues with the _brainhack cloud_, please open a
 Thank you to Oracle for Research for providing Oracle Cloud credits and related
 resources to support this project.
 
-<img src="https://user-images.githubusercontent.com/4021595/119061922-db877080-ba18-11eb-9882-d53a25ec88ee.png" width="250">
+<a href="https://www.oracle.com/research/?source=:pp:sn:::::RC_WWMK211117P00113:Evergreen_General_WWMK211117P00113_Sponshorship">
+  <img src="https://user-images.githubusercontent.com/4021595/119061922-db877080-ba18-11eb-9882-d53a25ec88ee.png" width="250">
+</a>
 
 ## License
 


### PR DESCRIPTION
Oracle requested to put a hyperlink to their research web page close to the oracle logo. 
I have now turned  all oracle logos (landing page, admins/index.md, docs.index.md) on the repo into a hyperlink to the research webpage.
(I also changed the logo on the tutorials/index.md page, but accidentally committed directly into the repo)

- [ ] Hyperlinks working?
