### PR TITLE
Add caveat about 'generate key pair for me' to tutorial

### DIFF
--- a/content/en/tutorials/vm.md
+++ b/content/en/tutorials/vm.md
@@ -75,7 +75,7 @@ Paste it in the Add SSH keys section
 ![image](https://user-images.githubusercontent.com/4021595/157350315-ee920db6-0bf2-45de-9dd3-3f96c9bbc8fc.png)
 
 {{% alert title="Warning" color="warning" %}}
-Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or in your local shell). The option `generate a key pair for me` will not work and result in generating a .key file, which is used for  connecting to APIs and will not work for `ssh` connections.
+Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or in your local shell). The option `generate a key pair for me` does not work and results in a Permission denied (publickey,gssapi-keyex,gssapi-with-mic) error.
 {{% /alert %}} 
 
 ### Disk size

--- a/content/en/tutorials/vm.md
+++ b/content/en/tutorials/vm.md
@@ -74,6 +74,10 @@ Paste it in the Add SSH keys section
 
 ![image](https://user-images.githubusercontent.com/4021595/157350315-ee920db6-0bf2-45de-9dd3-3f96c9bbc8fc.png)
 
+{{% alert title="Warning" color="warning" %}}
+Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or your local shell). The option `generate key pairs` will not work and result in generating a .key file, which is used for APIs and not for `ssh` connection.
+{{% /alert %}} 
+
 ### Disk size
 
 You can specify a custom boot volume size, but you can also increase this easily

--- a/content/en/tutorials/vm.md
+++ b/content/en/tutorials/vm.md
@@ -75,7 +75,7 @@ Paste it in the Add SSH keys section
 ![image](https://user-images.githubusercontent.com/4021595/157350315-ee920db6-0bf2-45de-9dd3-3f96c9bbc8fc.png)
 
 {{% alert title="Warning" color="warning" %}}
-Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or in your local shell). The option `generate a key pair for me` will not work and result in generating a .key file, which is used for  connecting to APIs and does not work for `ssh` connections.
+Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or in your local shell). The option `generate a key pair for me` will not work and result in generating a .key file, which is used for  connecting to APIs and will not work for `ssh` connections.
 {{% /alert %}} 
 
 ### Disk size

--- a/content/en/tutorials/vm.md
+++ b/content/en/tutorials/vm.md
@@ -75,7 +75,7 @@ Paste it in the Add SSH keys section
 ![image](https://user-images.githubusercontent.com/4021595/157350315-ee920db6-0bf2-45de-9dd3-3f96c9bbc8fc.png)
 
 {{% alert title="Warning" color="warning" %}}
-Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or your local shell). The option `generate key pairs` will not work and result in generating a .key file, which is used for APIs and not for `ssh` connection.
+Make sure to generate the key pair via `ssh-keygen` in the cloud shell (or in your local shell). The option `generate a key pair for me` will not work and result in generating a .key file, which is used for  connecting to APIs and does not work for `ssh` connections.
 {{% /alert %}} 
 
 ### Disk size


### PR DESCRIPTION
This PR adds a caveat about the option 'generate a key pair for me' instead of using the ssh key generate via ssh-keygen.
'generate a key pair for me" results in a .key file which does not work for ssh connections.

Checks:
- [ ] Is the warning label displayed properly?