### PR TITLE
Updated HPC documentation

### DIFF
--- a/content/en/tutorials/gh_runner.md
+++ b/content/en/tutorials/gh_runner.md
@@ -12,7 +12,7 @@ This section describes how to setup a Github action runner on the cloud that you
 can then use to run huge Github workflows that wouldn't run in the hosted
 runners :)
 
-## Create a new VM or HCP
+## Create a new VM or HPC
 
 See our [VM](./../vm) or [HPC](./../hpc) Tutorials.
 

--- a/content/en/tutorials/gh_runner.md
+++ b/content/en/tutorials/gh_runner.md
@@ -12,9 +12,9 @@ This section describes how to setup a Github action runner on the cloud that you
 can then use to run huge Github workflows that wouldn't run in the hosted
 runners :)
 
-## Create new VM
+## Create a new VM or HCP
 
-See our [VM Tutorial](./../vm)
+See our [VM](./../vm) or [HPC](./../hpc) Tutorials.
 
 ## Configure Github
 

--- a/content/en/tutorials/hpc.md
+++ b/content/en/tutorials/hpc.md
@@ -16,20 +16,30 @@ your own HPC cluster in the cloud. This tutorial here is a basic introduction to
 Download the Terraform configuration from here as a zip file:
 https://github.com/oracle-quickstart/oci-hpc/releases/tag/v2.8.0.5
 
+Make sure you selected the geographic region where you would like to create the resource.
+![image](https://user-images.githubusercontent.com/4021595/157349780-69fdf973-d4aa-4850-9f49-8ecca369f399.png)
+
 Then go to `Stacks` under `Resource Manager`:
 ![image](https://user-images.githubusercontent.com/4021595/161415757-409d264d-39e0-41f0-8bb0-3b5adc53abde.png)
 
-Choose `My Configuration` and upload the zip file.
+In the `List Scope` drop down menu, select your project title.  Choose `Create Stack` and upload the zip file.
 ![image](https://user-images.githubusercontent.com/4021595/161415784-56f78544-fa20-48de-ae7c-89f2154f5e58.png)
-
 
 Accept the defaults and add your public SSH key, disable `Use cluster network` (this is for MPI and not required for most people):
 ![image](https://user-images.githubusercontent.com/4021595/161415850-906a7cbf-8243-4df4-94b9-1dac7fcb1225.png)
+
+Specify the number of compute nodes you would like the HPC to have using `Initial cluster size`.
 
 This will then create a custom HPC for your project (it will take a couple of minutes to complete).
 
 Once everything is done you find the bastion IP (the "head node" or "login node") under Outputs: 
 ![image](https://user-images.githubusercontent.com/4021595/161416418-6fcf7712-646d-48ea-9861-743fd679ba28.png)
+
+If you selected the default options, you can now ssh into the HPC as follows:
+```
+ssh opc@ipbastion
+```
+
 
 Once logged in, you can create users using the `cluster` command:
 ```
@@ -42,6 +52,24 @@ There is a shared file storage (which can also be configured in size in the stac
 
 More information can be found here:
 https://github.com/oracle-quickstart/oci-hpc
+
+## Configuring node memory
+
+When you first submit jobs using `sbatch`, if you followed the above setup you may find you recieve the following error:
+```
+error: Memory specification can not be satisfied
+```
+
+This is happening as the `RealMemory` for each node (e.g. the amount of memory each compute node may use) has not yet been specified and defaults to a very low value. To rectify this, first work out how much memory to allocate to each node by running `scontrol show nodes` and looking at `FreeMem`.
+![image](MARKER)
+
+To change the `RealMemory`, you must edit the slurm configuration file (which may be found in `/etc/slurm/slurm.conf`). Inside the slurm configuration file you will find several lines which begin `NodeName=`. These specify the settings for each node. To fix the error, on each of these lines, add `RealMemory=AMOUNT` where `AMOUNT` is the amount of memory you wish to allow the node to use.
+![image](MARKER)
+
+Once you have done this, you must reconfigure slurm by running the following command:
+```
+sudo scontrol reconfigure
+```
 
 ## Advanced: Use MPI networking
 

--- a/content/en/tutorials/hpc.md
+++ b/content/en/tutorials/hpc.md
@@ -61,10 +61,10 @@ error: Memory specification can not be satisfied
 ```
 
 This is happening as the `RealMemory` for each node (e.g. the amount of memory each compute node may use) has not yet been specified and defaults to a very low value. To rectify this, first work out how much memory to allocate to each node by running `scontrol show nodes` and looking at `FreeMem`.
-![image](MARKER)
+![image](https://user-images.githubusercontent.com/4021595/176095292-c17e658b-0372-4c04-9f51-32d00c2e0f1c.png)
 
 To change the `RealMemory`, you must edit the slurm configuration file (which may be found in `/etc/slurm/slurm.conf`). Inside the slurm configuration file you will find several lines which begin `NodeName=`. These specify the settings for each node. To fix the error, on each of these lines, add `RealMemory=AMOUNT` where `AMOUNT` is the amount of memory you wish to allow the node to use.
-![image](MARKER)
+![image](https://user-images.githubusercontent.com/4021595/176095320-b9f55fb1-7365-4e8a-9a30-eee5117c12dc.png)
 
 Once you have done this, you must reconfigure slurm by running the following command:
 ```


### PR DESCRIPTION
This PR contains a few suggestions for the HPC documentation. These are just things that I wasn't sure on when first setting up a brainhack cloud and I understand if you don't feel it is necessary to include all the suggestions.

There are two lines where I tried to include images. These are lines [64 and 67 in the updated `hpc.md`](https://github.com/TomMaullin/brainhack_cloud/blob/951af59e0c3eaf84ca6360ea2bd7522726000f98/content/en/tutorials/hpc.md?plain=1#L64-L67) which should have the below images, respectively:
![freemem](https://user-images.githubusercontent.com/22241320/175936034-343f8fc0-c480-4038-aaf4-2cd1800a595e.png)
![realmem](https://user-images.githubusercontent.com/22241320/175936037-b8f7d4c4-ac3f-4954-a286-722585068746.png)

As I am not sure about the convention for including images on this repository I have just left the URL for these images as `MARKER`. Please let me know if you would like me to include these images and/or how.